### PR TITLE
[#2] feat: party join request api controller

### DIFF
--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyController.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyController.java
@@ -20,9 +20,10 @@ public class PartyController {
 //    partyService.join(reservation, partyId);
     try{
       Reservation reservation = builder.build();
+      return reservation.toString() + " -> reservation";
     }catch (IllegalArgumentException e){
       System.out.println("[IllegalArgumentException] member or user is null");
     }
-    return builder.toString();
+    return builder.toString() + " -> builder";
   }
 }

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyController.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyController.java
@@ -1,0 +1,28 @@
+package com.villain.play.ground.PlayGround.party;
+
+import com.villain.play.ground.PlayGround.reservation.Reservation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/party/")
+public class PartyController {
+
+  private final PartyService partyService;
+
+  @PostMapping("{partyId}/join")
+  public String join(@PathVariable("partyId") int partyId, @RequestBody Reservation.Builder builder){
+//    partyService.join(reservation, partyId);
+    try{
+      Reservation reservation = builder.build();
+    }catch (IllegalArgumentException e){
+      System.out.println("[IllegalArgumentException] member or user is null");
+    }
+    return builder.toString();
+  }
+}

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/reservation/Reservation.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/reservation/Reservation.java
@@ -1,6 +1,7 @@
 package com.villain.play.ground.PlayGround.reservation;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
@@ -10,6 +11,8 @@ public class Reservation {
   private String member;
   private String user;
 
+  @NoArgsConstructor
+  @ToString
   public static class Builder{
     String member;
     String user;
@@ -31,7 +34,7 @@ public class Reservation {
 
   // 선점할 멤버 미선택 시 객체 생성 불가 exception
   private Reservation(Builder builder){
-    if(builder.member == null)
+    if(builder.member == null|| builder.user == null)
       throw new IllegalArgumentException();
     this.member = builder.member;
     this.user = builder.user;

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/reservation/Reservation.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/reservation/Reservation.java
@@ -2,6 +2,7 @@ package com.villain.play.ground.PlayGround.reservation;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @ToString
@@ -11,8 +12,8 @@ public class Reservation {
   private String member;
   private String user;
 
-  @NoArgsConstructor
   @ToString
+  @Setter
   public static class Builder{
     String member;
     String user;


### PR DESCRIPTION
**1. RestController vs Controller Annotation**
- Controller 어노테이션은 반환이 View Resolver 로 연계되어 String 같은 형태로 소화하지 못한다. 
 - viewResolver 는 view 객체를 찾아가고
 - View 객체는 주어진 모델 데이터를 사용하여 HTML, JSON, XML, PDF 등 다양한 형태로 응답을 렌더링한다.
- RestController 는 Restful Web Service에서 사용되는 컨트롤러 어노테이션으로 주용도는 Json 형태로 객체 데이터를 반환하는 것

**2. PathVariable vs RequestParam Annotation**
- RequestParam 은 /api/v1/...?id=XXX  처럼 파라미터를 명시해주면서 요청한다
 - 여러개의 파라미터를 전달할때 유용 
- PathVariable 은 /api/v1/.../1 처럼 경로에 전달하려는 데이터를 드러내며 요청
 - 입력받을 파라미터가 많이 존재한다면 어떤 값이 입력되는지 알기 어렵다

 **3. @RequestBody Reservation reservation**
 - 이걸 추가하니까 컨트롤러에서 오류가 났었다. 
 - 원인: private 으로 선언된 Reservation 생성자 
  - 파라미터를 매핑할 때 기본 생성자를 기반으로 오브젝트 매핑을 하기 때문에 발생한 일
 - 해당 객체의 생성자는 이전에 테스트 코드를 작성하며 빌더 패턴으로 구현했었다.
  - Reservation.Builder 를 파라미터로 두어 에러는 발생하지 않았다. 다만 Builder 객체가 초기화되지 않은 상태로 controller 내부에 진입하게 된다. 해당 부분에 대해 추가적인 조사가 필요하다. 

[생각의 흐름](https://ambitious-recess-219.notion.site/controller-17575e05e52a80b29c89c0ce98630fe3?pvs=4)