### PR TITLE
[Feat/#16/join] 파티 참여 요청 처리

### DIFF
--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/album/Album.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/album/Album.java
@@ -39,6 +39,7 @@ public class Album {
   public Artist getArtist(){
     return this.artist;
   }
+  public String getName(){ return this.name; }
 
   public List<String> getMembers(){
     return this.artist.getMembers();

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/album/Album.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/album/Album.java
@@ -9,7 +9,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import java.util.List;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
@@ -30,5 +30,17 @@ public class Album {
   public Album(String name, Artist artist){
     this.name = name;
     this.artist = artist;
+  }
+
+  public boolean isArtist(String name){
+    return artist.isIdentifiedMember(name);
+  }
+
+  public Artist getArtist(){
+    return this.artist;
+  }
+
+  public List<String> getMembers(){
+    return this.artist.getMembers();
   }
 }

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/album/Album.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/album/Album.java
@@ -1,0 +1,34 @@
+package com.villain.play.ground.PlayGround.album;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import com.villain.play.ground.PlayGround.constant.Artist;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Entity
+public class Album {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private long id;
+
+  @Column
+  private String name;
+
+  @Column
+  @Enumerated(value = EnumType.STRING)
+  private Artist artist;
+
+  public Album(String name, Artist artist){
+    this.name = name;
+    this.artist = artist;
+  }
+}

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/constant/Artist.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/constant/Artist.java
@@ -17,4 +17,8 @@ public enum Artist {
     }
     return false;
   }
+
+  public List<String> getMembers(){
+    return this.members;
+  }
 }

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/constant/Artist.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/constant/Artist.java
@@ -1,0 +1,20 @@
+package com.villain.play.ground.PlayGround.constant;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum Artist {
+  XH(Arrays.asList("건일", "정수", "가온", "오드", "형준", "주연"));
+  private List<String> members;
+
+  Artist(List<String> members){
+    this.members = members;
+  }
+
+  public boolean isIdentifiedMember(String name){
+    for(String member: members){
+      if(member.equals(name)) return true;
+    }
+    return false;
+  }
+}

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/Party.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/Party.java
@@ -1,11 +1,15 @@
 package com.villain.play.ground.PlayGround.party;
 
+import com.villain.play.ground.PlayGround.album.Album;
+import com.villain.play.ground.PlayGround.constant.Artist;
 import com.villain.play.ground.PlayGround.reservation.Reservation;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,8 +35,9 @@ public class Party {
   private Long id;
   @Column
   private String platform;
-  @Column
-  private String album;
+  @ManyToOne
+  @JoinColumn(name = "album_id")
+  private Album album;
   @Column
   private Long leader;
   @Column
@@ -41,14 +46,16 @@ public class Party {
   private int maximum;
 
   private List<Reservation> reservationList;
+  private Artist artist;
 
   @Builder
-  public Party(String platform, String album, Long leader, Long recruit, int maximum){
+  public Party(String platform, Album album, Long leader, Long recruit, int maximum){
     this.platform=platform;
     this.album = album;
     this.leader = leader;
     this.recruit = recruit;
     this.maximum = maximum;
+    this.artist = album.getArtist();
   }
   public void addReservation(Reservation reservation){
     reservationList.add(reservation);

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/Party.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/Party.java
@@ -1,7 +1,6 @@
 package com.villain.play.ground.PlayGround.party;
 
 import com.villain.play.ground.PlayGround.album.Album;
-import com.villain.play.ground.PlayGround.constant.Artist;
 import com.villain.play.ground.PlayGround.reservation.Reservation;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -46,7 +45,6 @@ public class Party {
   private int maximum;
 
   private List<Reservation> reservationList;
-  private Artist artist;
 
   @Builder
   public Party(String platform, Album album, Long leader, Long recruit, int maximum){
@@ -55,7 +53,6 @@ public class Party {
     this.leader = leader;
     this.recruit = recruit;
     this.maximum = maximum;
-    this.artist = album.getArtist();
   }
   public void addReservation(Reservation reservation){
     reservationList.add(reservation);
@@ -74,5 +71,8 @@ public class Party {
 
   public void deleteAllReservations(){
     reservationList = new ArrayList<>();
+  }
+  public boolean isArtist(String name){
+    return album.isArtist(name) || name.equals(album.getName());
   }
 }

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/Party.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/Party.java
@@ -40,7 +40,7 @@ public class Party {
   @Column
   private int maximum;
 
-  private static List<Reservation> reservationList = new ArrayList<>();
+  private List<Reservation> reservationList;
 
   @Builder
   public Party(String platform, String album, Long leader, Long recruit, int maximum){

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyController.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyController.java
@@ -3,6 +3,7 @@ package com.villain.play.ground.PlayGround.party;
 import com.villain.play.ground.PlayGround.request.NewParty;
 import com.villain.play.ground.PlayGround.reservation.Reservation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +20,11 @@ public class PartyController {
   @PostMapping
   public void create(@RequestBody NewParty party){
     partyService.save(party);
+  }
+
+  @GetMapping("/{partyId}")
+  public Party read(@PathVariable("partyId") long partyId){
+    return partyService.getParty(partyId);
   }
 
   @PostMapping("/{partyId}/join")

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyController.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyController.java
@@ -27,7 +27,7 @@ public class PartyController {
     return partyService.getParty(partyId);
   }
 
-  @PostMapping("/{partyId}/join")
+  @PostMapping("/{partyId}/user")
   public String join(@PathVariable("partyId") int partyId, @RequestBody Reservation reservation){
 //    partyService.join(reservation, partyId);
     try{

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
@@ -30,9 +30,6 @@ public class PartyService {
       throw new IllegalArgumentException("[ ERROR ] 존재하지 않는 파티 정보 입니다.");
     return party;
   }
-  public Party detail(Long id) {
-    return partyRepository.findPartyById(id);
-  }
 
   public void deleteAllReservations(Long id){
     Party party = partyRepository.findPartyById(id);

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
@@ -25,7 +25,10 @@ public class PartyService {
   }
 
   public Party getParty(Long id){
-    return partyRepository.findPartyById(id);
+    Party party =partyRepository.findPartyById(id);
+    if(party == null)
+      throw new IllegalArgumentException("[ ERROR ] 존재하지 않는 파티 정보 입니다.");
+    return party;
   }
   public Party detail(Long id) {
     return partyRepository.findPartyById(id);

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
@@ -19,6 +19,7 @@ public class PartyService {
     String member = request.getMember();
     if(party.isReservedMember(member)) throw new IllegalArgumentException("[Error] Already reserved member. Please choose other one.");
 
+
     party.addReservation(request);
   }
 

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
@@ -18,7 +18,7 @@ public class PartyService {
 
     String member = request.getMember();
     if(party.isReservedMember(member)) throw new IllegalArgumentException("[Error] Already reserved member. Please choose other one.");
-
+    if(party.isArtist(member) == false)throw new IllegalArgumentException("[Error] Please choose this album's artist.");
 
     party.addReservation(request);
   }

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
@@ -15,6 +15,7 @@ public class PartyService {
   public void join(Reservation request){
     Long partyId = request.getPartyId();
     Party party = partyRepository.findPartyById(partyId);
+    party.addReservation(request);
   }
 
   public Party save(NewParty newParty){

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/party/PartyService.java
@@ -15,6 +15,10 @@ public class PartyService {
   public void join(Reservation request){
     Long partyId = request.getPartyId();
     Party party = partyRepository.findPartyById(partyId);
+
+    String member = request.getMember();
+    if(party.isReservedMember(member)) throw new IllegalArgumentException("[Error] Already reserved member. Please choose other one.");
+
     party.addReservation(request);
   }
 

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/request/NewParty.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/request/NewParty.java
@@ -1,6 +1,7 @@
 package com.villain.play.ground.PlayGround.request;
 
 
+import com.villain.play.ground.PlayGround.album.Album;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,14 +11,14 @@ import lombok.Setter;
 @Getter
 public class NewParty {
 
-  private String album;
+  private Album album;
   private String platform;
   private Long leader;
   private Long recruit;
   private int maximum;
 
   public boolean hasNullField(){
-    return album.equals("")|| platform.equals("")||
+    return album == null || platform.equals("")||
         leader==null || recruit == null ;
   }
 }

--- a/PlayGround/src/main/java/com/villain/play/ground/PlayGround/reservation/Reservation.java
+++ b/PlayGround/src/main/java/com/villain/play/ground/PlayGround/reservation/Reservation.java
@@ -2,7 +2,6 @@ package com.villain.play.ground.PlayGround.reservation;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/album/AlbumTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/album/AlbumTest.java
@@ -1,0 +1,35 @@
+package com.villain.play.ground.PlayGround.album;
+
+import com.villain.play.ground.PlayGround.constant.Artist;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class AlbumTest {
+
+  private Album album;
+  @BeforeEach
+  void setUp(){
+    album = new Album("Live and Fall", Artist.XH);
+  }
+
+  @Test
+  @DisplayName("앨범에 참여한 아티스트 정보를 얻을 수 있다.")
+  void test(){
+    Artist artist = album.getArtist();
+
+    Assertions.assertEquals("XH", artist.toString());
+    Assertions.assertEquals(6, artist.getMembers().size());
+  }
+
+  @Test
+  @DisplayName("앨범에 참여한 아티스트인지 구분할 수 있다.")
+  void test2(){
+    String fakeArtist = "호두영감";
+    Assertions.assertEquals(false, album.isArtist(fakeArtist));
+
+    String trueArtist = "정수";
+    Assertions.assertEquals(true, album.isArtist(trueArtist));
+  }
+}

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
@@ -66,6 +66,6 @@ class JoinPartyTest {
     Reservation newReservation = reservations.get(2);
 
     service.join(newReservation);
-    Assertions.assertThrows(IllegalAccessError.class, () -> service.join(newReservation));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> service.join(newReservation));
   }
 }

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
@@ -3,6 +3,8 @@ package com.villain.play.ground.PlayGround.party;
 
 import static org.mockito.Mockito.when;
 
+import com.villain.play.ground.PlayGround.album.Album;
+import com.villain.play.ground.PlayGround.constant.Artist;
 import com.villain.play.ground.PlayGround.reservation.Reservation;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +41,8 @@ class JoinPartyTest {
       reservations.add(new Reservation(partyId, member, user));
     }
 
-    party = new Party(targetId, "Sound Wave", "Live and Fall", 1L, 1L, 6, new ArrayList<>());
+    Album album = new Album("Live and Fall", Artist.XH);
+    party = new Party(targetId, "Sound Wave", album, 1L, 1L, 6, new ArrayList<>(), album.getArtist());
     leaderReservation = new Reservation(targetId, members[0], leader);
     party.addReservation(leaderReservation);
   }

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
@@ -1,9 +1,12 @@
 package com.villain.play.ground.PlayGround.party;
 
 
+import static org.mockito.Mockito.when;
+
 import com.villain.play.ground.PlayGround.reservation.Reservation;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,22 +26,37 @@ class JoinPartyTest {
   private PartyRepository partyRepository;
   List<Reservation> reservations = new ArrayList<>();
 
+  private Party party;
+  Long targetId = 2L;
+  Reservation leaderReservation;
+
   @BeforeEach
   void init() {
     String[] members = {"건일", "정수", "가온", "오드", "준한", "주연"};
-    long partyId = 1L;
+    long partyId = targetId;
     String user = "musk";
+    String leader = "ant";
     for(String member : members){
-      reservations.add(new Reservation(partyId, member, "musk"));
+      reservations.add(new Reservation(partyId, member, user));
     }
+
+    party = new Party(targetId, "Sound Wave", "Live and Fall", 1L, 1L, 6, new ArrayList<>());
+    leaderReservation = new Reservation(targetId, members[0], leader);
+    party.addReservation(leaderReservation);
   }
 
-
-
-  @DisplayName("기존 파티 참가 요청하기")
+  @DisplayName("기존에 존재하는 ant 파티 참가하기")
   @Test
-  void joinParty(){
-    for(Reservation reservation: reservations)
-      service.join(reservation);
+  void join(){
+    when(partyRepository.findPartyById(targetId)).thenReturn(party);
+    Reservation newReservation = reservations.get(2);
+
+    service.join(newReservation);
+
+    Party result = service.getParty(targetId);
+    List<Reservation> reservationList = result.getReservationList();
+
+    Assertions.assertEquals(leaderReservation, reservationList.get(0));
+    Assertions.assertEquals(newReservation, reservationList.get(1));
   }
 }

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
@@ -18,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class JoinPartyTest {
 
-  private static Long TEST_PARTY_ID = 0l;
   @InjectMocks
   private PartyService service;
 
@@ -58,5 +57,15 @@ class JoinPartyTest {
 
     Assertions.assertEquals(leaderReservation, reservationList.get(0));
     Assertions.assertEquals(newReservation, reservationList.get(1));
+  }
+
+  @DisplayName("이미 선점된 멤버로 파티 참가 불가")
+  @Test
+  void fail_join(){
+    when(partyRepository.findPartyById(targetId)).thenReturn(party);
+    Reservation newReservation = reservations.get(2);
+
+    service.join(newReservation);
+    Assertions.assertThrows(IllegalAccessError.class, () -> service.join(newReservation));
   }
 }

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
@@ -68,4 +68,17 @@ class JoinPartyTest {
     service.join(newReservation);
     Assertions.assertThrows(IllegalArgumentException.class, () -> service.join(newReservation));
   }
+
+  // 멤버에 대한 데이터베이스 필요
+  @DisplayName("존재하지 않는 멤버는 선점할 수 없다.")
+  @Test
+  void fail_join2(){
+    when(partyRepository.findPartyById(targetId)).thenReturn(party);
+    Reservation newReservation = reservations.get(2);
+    newReservation.setMember("아령");
+
+    Assertions.assertThrows(IllegalArgumentException.class, () -> service.join(newReservation));
+  }
+
+
 }

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/JoinPartyTest.java
@@ -42,7 +42,7 @@ class JoinPartyTest {
     }
 
     Album album = new Album("Live and Fall", Artist.XH);
-    party = new Party(targetId, "Sound Wave", album, 1L, 1L, 6, new ArrayList<>(), album.getArtist());
+    party = new Party(targetId, "Sound Wave", album, 1L, 1L, 6, new ArrayList<>());
     leaderReservation = new Reservation(targetId, members[0], leader);
     party.addReservation(leaderReservation);
   }
@@ -72,7 +72,6 @@ class JoinPartyTest {
     Assertions.assertThrows(IllegalArgumentException.class, () -> service.join(newReservation));
   }
 
-  // 멤버에 대한 데이터베이스 필요
   @DisplayName("존재하지 않는 멤버는 선점할 수 없다.")
   @Test
   void fail_join2(){

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/ManagePartyTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/ManagePartyTest.java
@@ -13,10 +13,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @ExtendWith(MockitoExtension.class)
 public class ManagePartyTest {
 
+  static long PARTY_ID=1L;
   static String PLATFORM = "sound wave";
   static String ALBUM = "Live and Fall";
   static long LEADER_ID = 1L;
@@ -37,28 +40,17 @@ public class ManagePartyTest {
     party = new NewParty(ALBUM, PLATFORM, LEADER_ID, RECRUIT_ID, MAXIMUM);
     nonRecruit = new NewParty(ALBUM, PLATFORM, LEADER_ID, RECRUIT_ID, MAXIMUM);
     nonRecruit.setRecruit(null);
-
-    Party party1 = new Party.PartyBuilder().platform("JYP shop").album("HELLO WORLD").recruit(0L)
-        .maximum(6).build();
-    Party party2 = new Party.PartyBuilder().platform("SoundWave").album("HELLO WORLD")
-        .recruit(0L).maximum(6).build();
-    Party party3 = new Party.PartyBuilder().platform("MyMusic").album("HELLO WORLD").recruit(0L)
-        .maximum(6).build();
-    Party party4 = new Party.PartyBuilder().platform("Hanter").album("HELLO WORLD").recruit(0L)
-        .maximum(6).build();
-    Party party5 = new Party.PartyBuilder().platform("Spotify").album("HELLO WORLD").recruit(0L)
-        .maximum(6).build();
-    Party party6 = new Party.PartyBuilder().platform("Melon").album("HELLO WORLD").recruit(0L)
-        .maximum(6).build();
+    nomal = new Party.PartyBuilder().platform(PLATFORM).leader(LEADER_ID).recruit(RECRUIT_ID).maximum(
+        MAXIMUM).album(ALBUM).build();
+    nomal.setId(PARTY_ID);
   }
 
 
   @DisplayName("파티를 생성할 수 있다.")
   @Test
   void create(){
-    nomal = new Party.PartyBuilder().platform(PLATFORM).leader(LEADER_ID).recruit(RECRUIT_ID).maximum(
-        MAXIMUM).album(ALBUM).build();
     when(partyRepository.save(any())).thenReturn(nomal);
+
     Party result = service.save(party);
 
     Assertions.assertEquals(PLATFORM, result.getPlatform());
@@ -73,5 +65,14 @@ public class ManagePartyTest {
   void cannot_create(){
     Assertions.assertThrows(IllegalArgumentException.class, () -> service.save(nonRecruit));
   }
+
+  @DisplayName("생성한 파티를 조회할 수 있다.")
+  @Test
+  void read_party(){
+    when(partyRepository.findPartyById(PARTY_ID)).thenReturn(nomal);
+    Party result = service.getParty(PARTY_ID);
+    Assertions.assertEquals(nomal, result);
+  }
+
 
 }

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/ManagePartyTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/ManagePartyTest.java
@@ -19,7 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 @ExtendWith(MockitoExtension.class)
 public class ManagePartyTest {
 
-  static long PARTY_ID=1L;
+  static long PARTY_ID = 1L;
+  static long INVALID_PARTY_ID = 0L;
   static String PLATFORM = "sound wave";
   static String ALBUM = "Live and Fall";
   static long LEADER_ID = 1L;
@@ -36,19 +37,20 @@ public class ManagePartyTest {
   static Party nomal;
 
   @BeforeEach
-  void set_up(){
+  void set_up() {
     party = new NewParty(ALBUM, PLATFORM, LEADER_ID, RECRUIT_ID, MAXIMUM);
     nonRecruit = new NewParty(ALBUM, PLATFORM, LEADER_ID, RECRUIT_ID, MAXIMUM);
     nonRecruit.setRecruit(null);
-    nomal = new Party.PartyBuilder().platform(PLATFORM).leader(LEADER_ID).recruit(RECRUIT_ID).maximum(
-        MAXIMUM).album(ALBUM).build();
+    nomal = new Party.PartyBuilder().platform(PLATFORM).leader(LEADER_ID).recruit(RECRUIT_ID)
+        .maximum(
+            MAXIMUM).album(ALBUM).build();
     nomal.setId(PARTY_ID);
   }
 
 
   @DisplayName("파티를 생성할 수 있다.")
   @Test
-  void create(){
+  void create() {
     when(partyRepository.save(any())).thenReturn(nomal);
 
     Party result = service.save(party);
@@ -62,17 +64,24 @@ public class ManagePartyTest {
 
   @DisplayName("빈 필드 존재 시 파티를 생성할 수 없다.")
   @Test
-  void cannot_create(){
+  void cannot_create() {
     Assertions.assertThrows(IllegalArgumentException.class, () -> service.save(nonRecruit));
   }
 
   @DisplayName("생성한 파티를 조회할 수 있다.")
   @Test
-  void read_party(){
+  void read_party() {
     when(partyRepository.findPartyById(PARTY_ID)).thenReturn(nomal);
     Party result = service.getParty(PARTY_ID);
     Assertions.assertEquals(nomal, result);
   }
 
 
+  @DisplayName("존재하지 않는 파티는 조회할 수 없다..")
+  @Test
+  void cannot_read() {
+    when(partyRepository.findPartyById(INVALID_PARTY_ID)).thenReturn(null);
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> service.getParty(INVALID_PARTY_ID));
+  }
 }

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/ManagePartyTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/ManagePartyTest.java
@@ -4,6 +4,8 @@ package com.villain.play.ground.PlayGround.party;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.villain.play.ground.PlayGround.album.Album;
+import com.villain.play.ground.PlayGround.constant.Artist;
 import com.villain.play.ground.PlayGround.request.NewParty;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,10 +24,10 @@ public class ManagePartyTest {
   static long PARTY_ID = 1L;
   static long INVALID_PARTY_ID = 0L;
   static String PLATFORM = "sound wave";
-  static String ALBUM = "Live and Fall";
   static long LEADER_ID = 1L;
   static long RECRUIT_ID = 1L;
   static int MAXIMUM = 6;
+  private Album album;
 
   @InjectMocks
   private PartyService service;
@@ -38,12 +40,13 @@ public class ManagePartyTest {
 
   @BeforeEach
   void set_up() {
-    party = new NewParty(ALBUM, PLATFORM, LEADER_ID, RECRUIT_ID, MAXIMUM);
-    nonRecruit = new NewParty(ALBUM, PLATFORM, LEADER_ID, RECRUIT_ID, MAXIMUM);
+    album = new Album("Live and Fall", Artist.XH);
+    party = new NewParty(album, PLATFORM, LEADER_ID, RECRUIT_ID, MAXIMUM);
+    nonRecruit = new NewParty(album, PLATFORM, LEADER_ID, RECRUIT_ID, MAXIMUM);
     nonRecruit.setRecruit(null);
     nomal = new Party.PartyBuilder().platform(PLATFORM).leader(LEADER_ID).recruit(RECRUIT_ID)
         .maximum(
-            MAXIMUM).album(ALBUM).build();
+            MAXIMUM).album(album).build();
     nomal.setId(PARTY_ID);
   }
 
@@ -56,7 +59,7 @@ public class ManagePartyTest {
     Party result = service.save(party);
 
     Assertions.assertEquals(PLATFORM, result.getPlatform());
-    Assertions.assertEquals(ALBUM, result.getAlbum());
+    Assertions.assertEquals(album, result.getAlbum());
     Assertions.assertEquals(LEADER_ID, result.getLeader());
     Assertions.assertEquals(RECRUIT_ID, result.getRecruit());
     Assertions.assertEquals(MAXIMUM, result.getMaximum());

--- a/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/PartyRepositoryTest.java
+++ b/PlayGround/src/test/java/com/villain/play/ground/PlayGround/party/PartyRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.villain.play.ground.PlayGround.party;
 
 
+import com.villain.play.ground.PlayGround.album.Album;
+import com.villain.play.ground.PlayGround.constant.Artist;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,16 +25,18 @@ class PartyRepositoryTest {
   @Autowired
   private PartyRepository partyRepository;
   private Party party;
+  private Album album;
 
   @BeforeEach
   void setup(){
     partyRepository.deleteAll();
+    album = new Album("Live and Fall", Artist.XH);
   }
 
   @DisplayName("객체 저장 및 조회")
   @Test
   void findPartyById() {
-    party = new Party.PartyBuilder().album("Hello NEW World").leader(0L).maximum(6)
+    party = new Party.PartyBuilder().album(album).leader(0L).maximum(6)
         .recruit(0L).platform("# form").build();
     System.out.println("party = " + party);
     Party savedParty = partyRepository.save(party);


### PR DESCRIPTION
테스트 완료
1. 기존에 존재하는 ant 파티 참가하기
2. 이미 선점된 멤버로 파티 참가 불가

todo
- 존재하지 않는 멤버는 선점할 수 없다.

해당 서비스가 동작하기에 앞서 필요한 내용
1. party 객체에서 선점 멤버와 관계를 맺어야 한다.

> 현재 party 클래스의 필드
```java
  @Id
  @GeneratedValue(strategy = GenerationType.IDENTITY)
  private Long id;
  @Column
  private String platform;
  @Column
  private String album;
  @Column
  private Long leader;
  @Column
  private Long recruit;
  @Column
  private int maximum;

  private List<Reservation> reservationList;
```
### 앨범에 대한 클래스 필요

party -> album -> member 와 같은 방향성을 가져야 할텐데

#### album.class
앨범 이름
아티스트 정보 -> list 형식으로 존재하겠지?, 클래스나 이넘으로 만들기에는 유닛 활동이나 솔로 활동... 같은 상황에서 확장성이 떨어질 것 같음